### PR TITLE
Add configurable separation between user log fields and environment fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,10 @@ Log line is a plain string of known format.
 
 ### Log fields transformations
 
-#### Default (legacy behavior) configuration 
+#### Default (legacy behavior) configuration
+
 Let's say we have docker engine log string:
+
 ```
 {"log":"{ \"sla\":             true, \"remote_addr\":             \"10.154.18.198\", \"remote_user\":             \"\", \"time_local\":              \"09/Jan/2018:12:07:48 +0700\", \"time_msec\":               \"1515474468.396\",\"request_method\": \"POST\", \"server_protocol\": \"HTTP/1.1\", \"request_uri\":                 \"/api/mis/getlocation\", \"status\":                   200, \"host\":                    \"api.2gis.com\", \"request_time\":             0.010, \"upstream_response_time\":  \"0.020, 0.078\", \"body_bytes_sent\":          213, \"http_referer\":            \"https://cerebro.2gis.test/\", \"http_user_agent\":         \"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:57.0) Gecko/20100101 Firefox/57.0\", \"request_id\":              \"d010f6631c81407596a7ff19aaf6312b\", \"geoip.location\":          \"0,0\", \"upstream_request_id\":     \"\" }\n","stream":"stderr","time":"2018-01-09T05:08:03.100481875Z"}
 ```
@@ -267,28 +269,36 @@ given that "container", "namespace" and "pod" are the container, namespace and p
 container's `config.v2.json` file or containerd container path.
 
 #### Fields unpacking control
+
 In general, the fields that will make up the resulting message are divided into three groups:
+
 * user log fields
 * docker/cri message top level fields
 * fields that Loggo sets up from the environment: container info, CLI parameters.
 
-For each group, one can select a field in the top-level map where you want to place the group's fields.
-These keys can be set via `user-log-fields-key`/`USER_LOG_FIELDS_KEY`, `cri-fields-key`/`CRI_FIELDS_KEY`, and `extends-fields-key`/`EXTENDS_FIELDS_KEY`.
-Flattening of user log is enabled by default, but can be disabled using `flatten-user-log`/`FLATTEN_USER_LOG`.
+For each group, one can select a field in the top-level map where you want to place the group's fields. These keys can
+be set via `user-log-fields-key`/`USER_LOG_FIELDS_KEY`, `cri-fields-key`/`CRI_FIELDS_KEY`, and `extends-fields-key`
+/`EXTENDS_FIELDS_KEY`. Flattening of user log is enabled by default, but can be disabled using `flatten-user-log`
+/`FLATTEN_USER_LOG`.
 
 Example:
 Input string:
+
 ```
 {"log":"{ \"sla\":             true, \"remote_addr\":             \"10.154.18.198\", \"remote_user\":             \"\", \"time_local\":              \"09/Jan/2018:12:07:48 +0700\", \"time_msec\":               \"1515474468.396\",\"request_method\": \"POST\", \"server_protocol\": \"HTTP/1.1\", \"request_uri\":                 \"/api/mis/getlocation\", \"status\":                   200, \"host\":                    \"api.2gis.com\", \"request_time\":             0.010, \"upstream_response_time\":  \"0.020, 0.078\", \"body_bytes_sent\":          213, \"http_referer\":            \"https://cerebro.2gis.test/\", \"http_user_agent\":         \"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:57.0) Gecko/20100101 Firefox/57.0\", \"request_id\":              \"d010f6631c81407596a7ff19aaf6312b\", \"geoip.location\":          \"0,0\", \"upstream_request_id\":     \"\" }\n","stream":"stderr","time":"2018-01-09T05:08:03.100481875Z"}
 ```
+
 Loggo is started with parameters:
+
 ```
   --no-flatten-user-log
   --user-log-fields-key="log"
   --cri-fields-key="cri"
   --extends-fields-key="environment"
 ```
+
 Environment variables are taken at random. Resulting output entry map would look like this:
+
 ```
 {
 	"cri": {
@@ -330,8 +340,11 @@ Environment variables are taken at random. Resulting output entry map would look
 	}
 }
 ```
-This logic is trying to avoid possible overrides between user log and environment fields.
-Using the same values of control keys is not recommended, as it can lead to the loss of values of certain fields.
+
+This keys-based approach is a try to avoid possible overwrites between user log and environment fields, but preserving
+backward compatibility. Using the same values of control keys is not recommended, as it can lead to the loss of values
+of certain fields.
+
 ### Reserved fields
 
 Some field names are considered service ones and **are removed** from the record after processing. Incomplete list of

--- a/cmd/loggo/main.go
+++ b/cmd/loggo/main.go
@@ -174,9 +174,10 @@ func main() {
 
 	stageParsing := stages.NewStageParsingEntry(
 		workersDispatcher.Out(),
-		parsers.ParseDockerFormat,
-		parsers.ParseContainerDFormat,
+		parsers.CreateParserDockerFormat(config.ParserConfig),
+		parsers.CreateParserContainerDFormat(config.ParserConfig),
 		parsers.ParseStringPlain,
+		config.ParserConfig.ExtendsFieldsKey,
 		logger,
 	)
 

--- a/cmd/loggo/main.go
+++ b/cmd/loggo/main.go
@@ -183,6 +183,7 @@ func main() {
 
 	stageParsingSLI := stages.NewStageParsingSLI(
 		stageParsing.Out(),
+		config.ParserConfig.UserLogFieldsKey,
 		parserSLI,
 		logger,
 	)

--- a/cmd/loggo/main.go
+++ b/cmd/loggo/main.go
@@ -188,6 +188,7 @@ func main() {
 	)
 	stageFiltering := stages.NewStageFiltering(
 		stageParsingSLI.Out(),
+		config.ParserConfig.UserLogFieldsKey,
 		logger,
 	)
 	stageMarshalling := stages.NewStageJSONMarshalling(

--- a/components/containers/provider_containers_test.go
+++ b/components/containers/provider_containers_test.go
@@ -136,7 +136,6 @@ func TestContainersProvider(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(containers))
 
-	fmt.Println(containers)
 	container := containers["/tmp/loggo-tests/loggo-containers/123abc/123abc-json.log"]
 	assert.Equal(t, "service", container.GetName())
 	assert.Equal(t, "123abc", container.GetPodName())

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -39,9 +39,9 @@ type FollowerConfig struct {
 }
 
 type ParserConfig struct {
-	UserLogTargetKey string
-	DockerFieldsKey  string
-	ExtendsFieldsKey   string
+	UserLogFieldsKey string
+	CRIFieldsKey     string
+	ExtendsFieldsKey string
 
 	FlattenUserLog bool
 }
@@ -290,15 +290,15 @@ func GetConfig() Config {
 		Envar("SLA_SERVICE_ANNOTATION_DOMAINS").
 		StringVar(&config.SLIExporterConfig.AnnotationSLADomains)
 
-	kingpin.Flag("user-log-target-field", "Entry field where user log should be put.").
+	kingpin.Flag("user-log-fields-key", "Entry field where user log should be put.").
 		Default("").
-		Envar("USER_LOG_TARGET_FIELD").
-		StringVar(&config.ParserConfig.UserLogTargetKey)
+		Envar("USER_LOG_FIELDS_KEY").
+		StringVar(&config.ParserConfig.UserLogFieldsKey)
 
-	kingpin.Flag("docker-fields-key", "Entry field where docker/containerd engine fields map should be put.").
+	kingpin.Flag("cri-fields-key", "Entry field where docker/containerd engine fields map should be put.").
 		Default("").
-		Envar("DOCKER_FIELDS_KEY").
-		StringVar(&config.ParserConfig.DockerFieldsKey)
+		Envar("cri_FIELDS_KEY").
+		StringVar(&config.ParserConfig.CRIFieldsKey)
 
 	kingpin.Flag("extends-fields-key", "Entry field where loggo and k8s extends fields map should be put.").
 		Default("").

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -291,17 +291,17 @@ func GetConfig() Config {
 		StringVar(&config.SLIExporterConfig.AnnotationSLADomains)
 
 	kingpin.Flag("user-log-target-field", "Entry field where user log should be put.").
-		Default("log").
+		Default("").
 		Envar("USER_LOG_TARGET_FIELD").
 		StringVar(&config.ParserConfig.UserLogTargetKey)
 
 	kingpin.Flag("docker-fields-key", "Entry field where docker/containerd engine fields map should be put.").
-		Default("docker").
+		Default("").
 		Envar("DOCKER_FIELDS_KEY").
 		StringVar(&config.ParserConfig.DockerFieldsKey)
 
 	kingpin.Flag("extends-fields-key", "Entry field where loggo and k8s extends fields map should be put.").
-		Default("environment").
+		Default("").
 		Envar("EXTENDS_FIELDS_KEY").
 		StringVar(&config.ParserConfig.ExtendsFieldsKey)
 

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -38,6 +38,14 @@ type FollowerConfig struct {
 	FromTailFlag                      bool
 }
 
+type ParserConfig struct {
+	UserLogTargetKey string
+	DockerFieldsKey  string
+	ExtendsFieldsKey   string
+
+	FlattenUserLog bool
+}
+
 type JournaldConfig struct {
 	LogJournalD   bool
 	JournaldPath  string
@@ -76,6 +84,7 @@ type FirehoseTransportConfig struct {
 // Config stores all configuration from environment or launch keys
 type Config struct {
 	K8SExtends              K8SExtends
+	ParserConfig            ParserConfig
 	FollowerConfig          FollowerConfig
 	JournaldConfig          JournaldConfig
 	SLIExporterConfig       SLIExporterConfig
@@ -280,6 +289,26 @@ func GetConfig() Config {
 		Default(AnnotationSLADomainsDefault).
 		Envar("SLA_SERVICE_ANNOTATION_DOMAINS").
 		StringVar(&config.SLIExporterConfig.AnnotationSLADomains)
+
+	kingpin.Flag("user-log-target-field", "Entry field where user log should be put.").
+		Default("log").
+		Envar("USER_LOG_TARGET_FIELD").
+		StringVar(&config.ParserConfig.UserLogTargetKey)
+
+	kingpin.Flag("docker-fields-key", "Entry field where docker/containerd engine fields map should be put.").
+		Default("docker").
+		Envar("DOCKER_FIELDS_KEY").
+		StringVar(&config.ParserConfig.DockerFieldsKey)
+
+	kingpin.Flag("extends-fields-key", "Entry field where loggo and k8s extends fields map should be put.").
+		Default("environment").
+		Envar("EXTENDS_FIELDS_KEY").
+		StringVar(&config.ParserConfig.ExtendsFieldsKey)
+
+	kingpin.Flag("flatten-user-log", "Whether to flatten user log or not.").
+		Default("true").
+		Envar("FLATTEN_USER_LOG").
+		BoolVar(&config.ParserConfig.FlattenUserLog)
 
 	kingpin.Flag("metrics-reset-interval-sec", "Prometheus metrics reset interval.").
 		Default("172800").

--- a/parsers/nginx.go
+++ b/parsers/nginx.go
@@ -5,9 +5,23 @@ import (
 	"math"
 	"strconv"
 	"strings"
+
+	"github.com/2gis/loggo/common"
 )
 
 var errInvalidNginxTimestamp = errors.New("upstream response time key doesn't contain proper value")
+
+func processNginxFields(outer common.EntryMap) {
+	if value, ok := outer[LogKeyUpstreamResponseTime]; ok {
+		if transformed, err := nginxUpstreamTimeTransform(value, false); err == nil {
+			outer[LogKeyUpstreamResponseTimeReplacement] = transformed
+		}
+
+		if transformed, err := nginxUpstreamTimeTransform(value, true); err == nil {
+			outer[LogKeyUpstreamResponseTimeTotal] = transformed
+		}
+	}
+}
 
 func nginxUpstreamTimeTransform(value interface{}, total bool) (float64, error) {
 	if v, ok := value.(float64); ok {

--- a/parsers/parser_containerd.go
+++ b/parsers/parser_containerd.go
@@ -24,9 +24,9 @@ func CreateParserContainerDFormat(config configuration.ParserConfig) func(line [
 
 		var outer = make(common.EntryMap)
 
-		setContainerDFields(outer, config.DockerFieldsKey, output[1], output[2])
+		setContainerDFields(outer, config.CRIFieldsKey, output[1], output[2])
 
-		if err := setLogFieldContent(outer, config.UserLogTargetKey, output[3], config.FlattenUserLog); err != nil {
+		if err := setLogFieldContent(outer, config.UserLogFieldsKey, output[3], config.FlattenUserLog); err != nil {
 			return nil, fmt.Errorf("error setting user log field: %w", err)
 		}
 

--- a/parsers/parser_containerd_test.go
+++ b/parsers/parser_containerd_test.go
@@ -7,17 +7,22 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/2gis/loggo/common"
+	"github.com/2gis/loggo/configuration"
 )
 
-var errTest = errors.New("test")
-
-var testCaseParserContainerD = []struct {
+type testCaseParserContainerD struct {
 	name  string
 	input string
 
+	config configuration.ParserConfig
+
 	errExpected      error
 	entryMapExpected common.EntryMap
-}{
+}
+
+var errTest = errors.New("test")
+
+var testCasesParserContainerD = []testCaseParserContainerD{
 	{
 		name:             "String does not contain 4 parts",
 		input:            "{\"log\":\"hello world\"}",
@@ -25,8 +30,9 @@ var testCaseParserContainerD = []struct {
 		errExpected:      errTest,
 	},
 	{
-		name:  "Positive scenario log field map",
-		input: "2020-09-10T07:00:03.585507743Z stdout F {\"hello\":\"world\",\"a\": 1,\"b\": null}",
+		name:   "Positive scenario log field map",
+		config: configFlattenTopLevel(),
+		input:  "2020-09-10T07:00:03.585507743Z stdout F {\"hello\":\"world\",\"a\": 1,\"b\": null}",
 		entryMapExpected: common.EntryMap{
 			"hello":  "world",
 			"a":      float64(1),
@@ -36,8 +42,9 @@ var testCaseParserContainerD = []struct {
 		},
 	},
 	{
-		name:  "Positive scenario, log field plain string",
-		input: "2020-09-10T07:00:03.585507743Z stdout F my message",
+		name:   "Positive scenario, log field plain string",
+		config: configFlattenTopLevel(),
+		input:  "2020-09-10T07:00:03.585507743Z stdout F my message",
 		entryMapExpected: common.EntryMap{
 			"log":    "my message",
 			"stream": "stdout",
@@ -47,10 +54,11 @@ var testCaseParserContainerD = []struct {
 }
 
 func TestParseContainerDFormat(t *testing.T) {
-	for _, testCase := range testCaseParserContainerD {
+	for _, testCase := range testCasesParserContainerD {
 
 		t.Run(testCase.name, func(t *testing.T) {
-			out, err := ParseContainerDFormat([]byte(testCase.input))
+			parser := CreateParserContainerDFormat(testCase.config)
+			out, err := parser([]byte(testCase.input))
 			assert.Equal(t, testCase.entryMapExpected, out)
 
 			if testCase.errExpected != nil {

--- a/parsers/parser_docker.go
+++ b/parsers/parser_docker.go
@@ -35,10 +35,10 @@ func CreateParserDockerFormat(config configuration.ParserConfig) func(line []byt
 		}
 
 		delete(outer, LogKeyLog)
-		setDockerFields(outer, config.DockerFieldsKey)
+		setDockerFields(outer, config.CRIFieldsKey)
 
 		if err := setLogFieldContent(
-			outer, config.UserLogTargetKey, logFieldContentString, config.FlattenUserLog); err != nil {
+			outer, config.UserLogFieldsKey, logFieldContentString, config.FlattenUserLog); err != nil {
 			return nil, fmt.Errorf("error setting user log field: %w", err)
 		}
 

--- a/parsers/parser_docker_test.go
+++ b/parsers/parser_docker_test.go
@@ -118,8 +118,8 @@ var (
 		{
 			name: "user log set to separate field, not flattened",
 			config: configuration.ParserConfig{
-				UserLogTargetKey: "user_log",
-				DockerFieldsKey:  "docker",
+				UserLogFieldsKey: "user_log",
+				CRIFieldsKey:     "docker",
 				FlattenUserLog:   false,
 			},
 			input: `{"time": "2018-01-09T05:08:03.100481875Z", "log": "{\"time\":{\"value\": 1.142}}"}`,
@@ -131,8 +131,8 @@ var (
 		{
 			name: "user log set to separate field, flattened",
 			config: configuration.ParserConfig{
-				UserLogTargetKey: "user_log",
-				DockerFieldsKey:  "docker",
+				UserLogFieldsKey: "user_log",
+				CRIFieldsKey:     "docker",
 				FlattenUserLog:   true,
 			},
 			input: `{"time": "2018-01-09T05:08:03.100481875Z", "log": "{\"time\":{\"value\": 1.142}}"}`,
@@ -144,8 +144,8 @@ var (
 		{
 			name: "flattening is on, user log field is empty, user log expected in top level dict",
 			config: configuration.ParserConfig{
-				UserLogTargetKey: "",
-				DockerFieldsKey:  "docker",
+				UserLogFieldsKey: "",
+				CRIFieldsKey:     "docker",
 				FlattenUserLog:   true,
 			},
 			input: `{"time": "2018-01-09T05:08:03.100481875Z", "log": "{\"time\":{\"value\": 1.142}}"}`,
@@ -157,8 +157,8 @@ var (
 		{
 			name: "flattening is off, user log field is empty, user log expected in log field of top level dict",
 			config: configuration.ParserConfig{
-				UserLogTargetKey: "",
-				DockerFieldsKey:  "docker",
+				UserLogFieldsKey: "",
+				CRIFieldsKey:     "docker",
 				FlattenUserLog:   false,
 			},
 			input: `{"time": "2018-01-09T05:08:03.100481875Z", "log": "{\"time\":{\"value\": 1.142}}"}`,
@@ -171,8 +171,8 @@ var (
 			name: "flattening is on, user log field key and docker fields key is empty, " +
 				"user log expected to override docker variables (legacy behavior)",
 			config: configuration.ParserConfig{
-				UserLogTargetKey: "",
-				DockerFieldsKey:  "",
+				UserLogFieldsKey: "",
+				CRIFieldsKey:     "",
 				FlattenUserLog:   true,
 			},
 			input: `{"time": "2018-01-09T05:08:03.100481875Z", "log": "{\"time\": 1.142, \"test\": \"value\"}"}`,
@@ -240,8 +240,8 @@ func TestSeparateDockerUserLogFieldsSet(t *testing.T) {
 
 func configFlattenTopLevel() configuration.ParserConfig {
 	return configuration.ParserConfig{
-		UserLogTargetKey: "",
-		DockerFieldsKey:  "",
+		UserLogFieldsKey: "",
+		CRIFieldsKey:     "",
 		FlattenUserLog:   true,
 	}
 }

--- a/stages/stage_filtering_test.go
+++ b/stages/stage_filtering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/2gis/loggo/common"
 	"github.com/2gis/loggo/logging"
 	"github.com/2gis/loggo/parsers"
@@ -18,7 +19,50 @@ func TestStageFiltering(t *testing.T) {
 	}
 
 	input := make(chan common.EntryMap, len(inputMessages))
-	stage := NewStageFiltering(input, logging.NewLoggerDefault())
+	stage := NewStageFiltering(input, "", logging.NewLoggerDefault())
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		StageInit(stage, 2)
+		wg.Done()
+	}()
+
+	for _, message := range inputMessages {
+		input <- message
+	}
+	close(input)
+
+	outputMessages := make([]common.EntryMap, 0, 2)
+
+	for message := range stage.Out() {
+		outputMessages = append(outputMessages, message)
+	}
+
+	for _, message := range outputMessages {
+		_, ok := message[parsers.LogKeyLogging]
+		assert.False(t, ok)
+		_, ok = message[parsers.LogKeySLA]
+		assert.False(t, ok)
+	}
+
+	assert.Len(t, outputMessages, 2)
+	wg.Wait()
+}
+
+func TestStageFilteringNestedField(t *testing.T) {
+	inputMessages := []common.EntryMap{
+		{"log": "test"},
+		{"log": map[string]interface{}{
+			parsers.LogKeyLogging: true, parsers.LogKeySLA: false,
+		}},
+		{"log": map[string]interface{}{
+			parsers.LogKeyLogging: false, parsers.LogKeySLA: true,
+		}},
+	}
+
+	input := make(chan common.EntryMap, len(inputMessages))
+	stage := NewStageFiltering(input, "log", logging.NewLoggerDefault())
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 

--- a/stages/stage_parsing_entry_test.go
+++ b/stages/stage_parsing_entry_test.go
@@ -45,7 +45,7 @@ func TestStageParsingEntryTest(t *testing.T) {
 	}
 
 	input := make(chan *common.Entry, len(expectations))
-	stage := NewStageParsingEntry(input, parserFunctionTest, nil, parserFunctionDefaultTest, logging.NewLoggerDefault())
+	stage := NewStageParsingEntry(input, parserFunctionTest, nil, parserFunctionDefaultTest, "", logging.NewLoggerDefault())
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 

--- a/stages/stage_parsing_sli_test.go
+++ b/stages/stage_parsing_sli_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/2gis/loggo/common"
 	"github.com/2gis/loggo/logging"
 	"github.com/2gis/loggo/tests/mocks"
@@ -13,7 +14,7 @@ import (
 func TestStageParsingSLITest(t *testing.T) {
 	input := make(chan common.EntryMap)
 	parser := mocks.NewSLIMock()
-	stage := NewStageParsingSLI(input, parser, logging.NewLoggerDefault())
+	stage := NewStageParsingSLI(input, "", parser, logging.NewLoggerDefault())
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 


### PR DESCRIPTION
A try to address #9 .
Instead of unpacking user log fields to top level entry map without options, introduce a configurable choice: whether to flatten the user log or not, and in which fields to put the user log, and for the top-level docker / CRI dictionary fields, as well as fields added by the loggo.
Notes:
* The "old 2GIS" behavior is achieved by a combination of a flatten flag and empty field key values: empty field is considered as "put it to entry's top level".
* If user log, docker and environment fields keys are set, corresponding groups of fields are getting put into corresponding submaps of top-level entryMap.
* Flattening is applied only to user log fields group, if enabled.

Four additional configuration fields are not a very elegant solution, maybe someone will suggest a better one.

There's still few tests to write, and this logic should be properly documented, will be done shortly; but can already be reviewed at this point. Refactored and expanded old parser's unit tests accordingly.