### PR TITLE
Add binary building to Dockerfile, update base image to debian:bullseye

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 go:
-  - "1.16.3"
+  - "1.16.8"
 
 before_install:
   - sudo apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
-FROM ubuntu:20.04
-COPY ./build/loggo /loggo
+FROM golang:1.16.8-bullseye as builder
+RUN apt update && apt install -y libsystemd-dev
+WORKDIR /src
+COPY . /src/
+RUN make build
+
+FROM debian:bullseye
+COPY --from=builder /src/build/loggo /loggo
 CMD ["/loggo"]


### PR DESCRIPTION
Changes:

* `go build` in Dockerfile is needed for Automated Builds on hub.docker.com.
* It seems to be better if we will have the same libsystemd version in build and runtime stages.
* Golang updated to 1.16.8 because there is no golang:1.16.3 image based on debian:bullseye.

---

fixes #14